### PR TITLE
LGA 2708: Set up RabbitMQ to replicate MQ Locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ python manage.py
 python manage.py --host 127.0.0.1 --port 8026
 ```
 
+## Running via Docker
 
 #### Running the service locally with RabbitMQ via Docker
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ pip install -U pip
 pip install -r requirements.txt
 ```
 
-#### 5) Launch the service
+#### 5) Launch the service locally without a message queue
 
 ```
 python manage.py
@@ -58,12 +58,18 @@ python manage.py
 python manage.py --host 127.0.0.1 --port 8026
 ```
 
-## Running via Docker
+
+#### Running the service locally with RabbitMQ via Docker
 
 ```
-docker build -t govuk_notify_orchestrator .
+./run_local.sh
+```
 
-docker run -d --name govuk_notify_orchestrator -p 8026:8026 govuk_notify_orchestrator
+#### Running the service without RabbitMQ via Docker
+
+```
+docker-compose down --remove-orphans
+docker-compose up
 ```
 
 ## Documentation

--- a/compose.yaml
+++ b/compose.yaml
@@ -16,15 +16,15 @@ services:
     container_name: rabbitmq
     image: rabbitmq:3-management-alpine
     ports:
-      - '5672:5672'   # Advanced Message Queuing Protocol
-      - '15672:15672' # Port for the management API
+      - "5672:5672" # Advanced Message Queuing Protocol
+      - "15672:15672" # Port for the management API
     volumes:
       - ./config/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf
     healthcheck:
-      test: [ "CMD", "nc", "-z", "localhost", "5672" ]
+      test: ["CMD", "nc", "-z", "localhost", "5672"]
       interval: 5s
       timeout: 10s
       retries: 3
     profiles:
-    # RabbitMQ will not run unless COMPOSE_PROFILES is set to 'development'
+      # RabbitMQ will not run unless COMPOSE_PROFILES is set to 'development'
       - development

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,29 @@
+version: "3.9"
+
+services:
+  api:
+    container_name: govuk_notify_orchestrator
+    build: .
+    ports:
+      - "8026:8026"
+    restart: "no"
+    depends_on:
+      rabbitmq:
+        condition: "service_healthy"
+        required: false
+
+  rabbitmq:
+    container_name: rabbitmq
+    image: rabbitmq:3-management-alpine
+    ports:
+      - '5672:5672'
+      - '15672:15672'
+    volumes:
+      - ./config/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf
+    healthcheck:
+      test: [ "CMD", "nc", "-z", "localhost", "5672" ]
+      interval: 5s
+      timeout: 10s
+      retries: 3
+    profiles:
+      - development

--- a/compose.yaml
+++ b/compose.yaml
@@ -16,8 +16,8 @@ services:
     container_name: rabbitmq
     image: rabbitmq:3-management-alpine
     ports:
-      - '5672:5672'
-      - '15672:15672'
+      - '5672:5672'   # Advanced Message Queuing Protocol
+      - '15672:15672' # Port for the management API
     volumes:
       - ./config/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf
     healthcheck:
@@ -26,4 +26,5 @@ services:
       timeout: 10s
       retries: 3
     profiles:
+    # RabbitMQ will not run unless COMPOSE_PROFILES is set to 'development'
       - development

--- a/config/rabbitmq.conf
+++ b/config/rabbitmq.conf
@@ -1,0 +1,1 @@
+log.console.level = error

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,9 +1,22 @@
 # Development Guide
 
-## How to start a local server
+## How to start a local version of the API (with no message queue) 
 
 ```
 python manage.py
+```
+
+## How to start a docker version of the API (With RabbitMQ)
+
+```
+./run_local.sh
+```
+
+## How to start a docker version of the API (Without RabbitMQ)
+
+```
+docker-compose down --remove-orphans
+docker-compose up
 ```
 
 ## How do I run tests

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,6 +1,6 @@
 # Development Guide
 
-## How to start a local version of the API (with no message queue) 
+## How to start a local version of the API (with no message queue)
 
 ```
 python manage.py

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -1,9 +1,14 @@
-## Running via Docker
+## How to start a docker version of the API (With RabbitMQ)
 
 ```
-docker build -t govuk_notify_orchestrator .
+./run_local.sh
+```
 
-docker run -d --name govuk_notify_orchestrator -p 8026:8026 govuk_notify_orchestrator
+## How to start a docker version of the API (Without RabbitMQ)
+
+```
+docker-compose down --remove-orphans
+docker-compose up
 ```
 
 ## Running unit testing in the docker container

--- a/run_local.sh
+++ b/run_local.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+export ENVIRONMENT=${1:-development}
+export COMPOSE_PROFILES=$ENVIRONMENT
+echo "running environment $ENVIRONMENT"
+docker-compose down --remove-orphans
+docker-compose up

--- a/run_local.sh
+++ b/run_local.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 export ENVIRONMENT=${1:-development}
+
+# COMPOSE_PROFILES is used to set the docker compose profile
+# If this is set to development then RabbitMQ will launch with the API
 export COMPOSE_PROFILES=$ENVIRONMENT
+
 echo "running environment $ENVIRONMENT"
+
 docker-compose down --remove-orphans
 docker-compose up


### PR DESCRIPTION
## What does this pull request do?
### [LGA 2708](https://dsdmoj.atlassian.net/jira/software/c/projects/LGA/boards/226?selectedIssue=LGA-2708)
#### Sets up RabbitMQ with Docker Compose for local testing of the message queue.
- Adds a `compose.yaml` file for docker-compose
- Adds the `rabbitmq:3-management-alpine` image to the docker-compose file
   - This image will only be included when running in the development profile `(COMPOSE_PROFILES=development)`
 - Adds a `run_local.sh` script which sets the environment variable to 'development' and runs `docker-compose`
 - Reflects the changes in the documentation

## Any other changes that would benefit highlighting?

- RabbitMQ runs on the default Advanced Message Queuing Protocol port of 5672
- The queue manager API can be found at port 15672

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
