### PR TITLE
LGA 2688 Ensure MAX_RETRIES is typecast to an integer

### DIFF
--- a/config/base_config.py
+++ b/config/base_config.py
@@ -42,6 +42,10 @@ class BaseConfig:
 
     # Limits the number of retries, 32 Retries means the email will be lost if after 24 hours we are still unable to get a response
     MAX_RETRIES = os.environ.get("MAX_RETRIES", 32)
+    try:
+        MAX_RETRIES = int(MAX_RETRIES)
+    except TypeError as e:
+        raise TypeError(f"MAX_RETRIES could not be interepreted as an integer, {e}")
 
     SENTRY_DSN = os.environ.get("SENTRY_DSN")
 

--- a/config/base_config.py
+++ b/config/base_config.py
@@ -45,7 +45,7 @@ class BaseConfig:
     try:
         MAX_RETRIES = int(MAX_RETRIES)
     except TypeError as e:
-        raise TypeError(f"MAX_RETRIES could not be interepreted as an integer, {e}")
+        raise TypeError(f"MAX_RETRIES could not be interpreted as an integer, {e}")
 
     SENTRY_DSN = os.environ.get("SENTRY_DSN")
 


### PR DESCRIPTION
## What does this pull request do?

- Ensures the environment variable `MAX_RETRIES` is typecast to an integer.
- Handles TypeErrors if that typecast cannot be performed.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
