### PR TITLE
SHA pin actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,50 +41,6 @@ jobs:
             docker build -t ${AWS_ECR_REGISTRY_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com/${ECR_REPOSITORY}:${CIRCLE_SHA1} .
             docker push ${AWS_ECR_REGISTRY_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com/${ECR_REPOSITORY}:${CIRCLE_SHA1}
 
-  image_security_scan:
-    executor: aws-ecr/default # use the aws-ecr/default executor to start the docker daemon
-    steps:
-      # Checkout your repository
-      - checkout
-      # Authenticate to AWS using OIDC v2 with the AWS CLI
-      - aws-cli/setup:
-          role_arn: $ECR_ROLE_TO_ASSUME # this will use the env var
-          region: $ECR_REGION # this will use the env var
-      # Authenticate to the ECR repository using the standard command
-      - run:
-          name: Create target tags
-          command: echo "export ECR_DEPLOY_IMAGE=${AWS_ECR_REGISTRY_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com/$ECR_REPOSITORY:$CIRCLE_SHA1" >> $BASH_ENV
-      - run:
-          name: Authenticate with AWS ECR
-          command: aws ecr get-login-password --region $ECR_REGION | docker login --username AWS --password-stdin ${AWS_ECR_REGISTRY_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com
-
-      - run:
-          name: Install trivy
-          command: |
-            sudo apt-get update
-            sudo apt-get install -y curl wget
-            VERSION=$(
-                curl --silent "https://api.github.com/repos/aquasecurity/trivy/releases/latest" | \
-                grep '"tag_name":' | \
-                sed -E 's/.*"v([^"]+)".*/\1/'
-            )
-
-            wget https://github.com/aquasecurity/trivy/releases/download/v${VERSION}/trivy_${VERSION}_Linux-64bit.tar.gz
-            tar zxvf trivy_${VERSION}_Linux-64bit.tar.gz
-            sudo mv trivy /usr/local/bin
-      - run:
-          name: Pull down image
-          command: |
-            docker pull ${ECR_DEPLOY_IMAGE}
-      - run:
-          name: Scan for vulnerabilities (informative, non-breaking)
-          command: |
-            trivy image --exit-code 0 --severity UNKNOWN,LOW,MEDIUM,HIGH --no-progress ${ECR_DEPLOY_IMAGE}
-      - run:
-          name: Scan for breaking vulnerabilities
-          command: |
-            trivy image --exit-code 1 --severity CRITICAL --no-progress ${ECR_DEPLOY_IMAGE}
-
   lint:
     docker:
       - image: cimg/python:3.11
@@ -223,10 +179,6 @@ workflows:
             - lint
             - unit_test
             - integration_test
-      - image_security_scan:
-          context: laa-govuk-notify-orchestrator
-          requires:
-            - build
       - deploy:
           name: development_deploy
           namespace: development
@@ -239,7 +191,6 @@ workflows:
           type: approval
           requires:
             - development_deploy
-            - image_security_scan
       - deploy:
           name: staging_deploy
           namespace: staging
@@ -252,7 +203,6 @@ workflows:
           type: approval
           requires:
             - staging_deploy
-            - image_security_scan
           filters:
             branches:
               only:

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -8,7 +8,6 @@ jobs:
   format-code:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: ministryofjustice/github-actions/code-formatter@v14
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.02
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -8,6 +8,8 @@ jobs:
   format-code:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.02
+      - uses: actions/checkout@@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.02
+      - uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 #v3.6.1
+      - run: ruff format --check .
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What does this pull request do?


Pins the SHA for the github action
replaces teh MoJ code formatter with astral-sh ruff-formatter that we use elsewhere because the latest MoJ one is deprecated and earlier versions pin insecure trivy versions
https://github.com/ministryofjustice/github-actions/releases
rmove the trivy scan because of compromise

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
